### PR TITLE
Legalsylvain patch 1

### DIFF
--- a/voodoo/odoo/hook.py
+++ b/voodoo/odoo/hook.py
@@ -37,12 +37,12 @@ class GenerateDevComposeFile(GenerateDevComposeFile):
     _map_user_for_service = ['db']
 
     def get_default_volume(self):
-        path = local.path('~/.voodoo/shared')._path
+        path = 'home/${USER}/.voodoo/shared'
         return [':'.join([path, path])]
 
     def _update_config_file(self):
         super(GenerateDevComposeFile, self)._update_config_file()
-        path = local.path('~/.voodoo/shared/maintainer_quality_tools')._path
+        path = 'home/${USER}/.voodoo/shared/maintainer_quality_tools'
         self.config['services']['odoo']['environment'].append(
             "MAINTAINER_QUALITY_TOOLS=%s" % path)
 

--- a/voodoo/odoo/hook.py
+++ b/voodoo/odoo/hook.py
@@ -37,12 +37,12 @@ class GenerateDevComposeFile(GenerateDevComposeFile):
     _map_user_for_service = ['db']
 
     def get_default_volume(self):
-        path = 'home/${USER}/.voodoo/shared'
+        path = '/home/${USER}/.voodoo/shared'
         return [':'.join([path, path])]
 
     def _update_config_file(self):
         super(GenerateDevComposeFile, self)._update_config_file()
-        path = 'home/${USER}/.voodoo/shared/maintainer_quality_tools'
+        path = '/home/${USER}/.voodoo/shared/maintainer_quality_tools'
         self.config['services']['odoo']['environment'].append(
             "MAINTAINER_QUALITY_TOOLS=%s" % path)
 


### PR DESCRIPTION
Problem : 

* create a new project (voodoo new ...)
* it will generate a dev docker compose file with lines like : 

```
odoo:
  environment:
    - MAINTAINER_QUALITY_TOOLS=/home/sylvain/.voodoo/shared/maintainer_quality_tools

[... blablabla]

  volumes:
    - /home/sylvain/.voodoo/shared:/home/sylvain/.voodoo/shared
```

* push the voodoo project and share it with "other_guy"

when the other guy will pull the project, he will not have the folder /hom/sylvain/ but instead /home/other_guys.

CC : @akretion/akretion-team 