### PR TITLE
[FIX] typo in voodoo migrate

### DIFF
--- a/voodoo/main.py
+++ b/voodoo/main.py
@@ -354,7 +354,7 @@ class VoodooMigrate(VoodooSub):
             self._run_ak("upgrade")
             self._run_ak("db", "dump", "--force", "migrated_%s.dump" % version)
             end = datetime.now()
-            self._log("Migrate to version %s in %s" % (version, end-start))
+            self.log("Migrate to version %s in %s" % (version, end-start))
         for log in self._logs:
             logger.info(log)
 


### PR DESCRIPTION
_log doesn't existe in VoodooMigrate