### PR TITLE
Compose project name

### DIFF
--- a/docky/cmd/base.py
+++ b/docky/cmd/base.py
@@ -60,18 +60,15 @@ class Docky(cli.Application):
                 'value in ~/.docky/config.yml')
 
         # TODO maybe remove me with the code of downloading
-        # the maintainer tools
+        # the maintainer tools
         self.shared_folder = os.path.join(
             self.config.home, '.docky', 'shared')
         self.project = Project(self.env, self.config)
         self.project.build_network()
         self.proxy = Proxy(self.project)
-        project_name = local.env.get(
-            'COMPOSE_PROJECT_NAME', self.project.name
-        )
         self.compose = local['docker-compose'][
             '-f', self.project.compose_file_path,
-            '--project-name', project_name]
+            '--project-name', self.project.name]
 
     @cli.switch("--verbose", help="Verbose mode", group = "Meta-switches")
     def set_log_level(self):

--- a/docky/common/project.py
+++ b/docky/common/project.py
@@ -67,7 +67,10 @@ class Project(object):
             raise_error("No dev.docker-compose.yml file, abort!")
 
     def _get_project_name(self):
-        return "%s_%s" % (local.env.user, local.cwd.name)
+        return local.env.get(
+            'COMPOSE_PROJECT_NAME',
+            '%s_%s' % (local.env.user, local.cwd.name)
+        )
 
     def get_containers(self, service=None):
         project = get_project(


### PR DESCRIPTION
Hello,

The COMPOSE_PROJECT_NAME environment variable is not used every where accross all docky command.
Just a refactor to fix this issue 

Thanks