### PR TITLE
fix default dev.docker-compose.yml volumes section

### DIFF
--- a/docky/template/odoo.docker-compose.yml
+++ b/docky/template/odoo.docker-compose.yml
@@ -108,5 +108,8 @@ services:
     links:
       - db
     volumes:
-      - ./odoo:/opt/odoo
+      - ./odoo:/odoo
+      - ./data/addons:/data/odoo/addons
+      - ./data/filestore:/data/odoo/filestore
+      - ./data/sessions:/data/odoo/sessions
 version: '3'


### PR DESCRIPTION
according to what I use and according also to Saint Shopinvader, the new canonical docky reference:
https://github.com/akretion/docker-odoo-shopinvader/blob/10.0/dev.docker-compose.yml#L34
