### PR TITLE
requests<3,2.20.0 as in recent docker-compose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ python-slugify
 
 # Only for solving installation issue with pip that fail to
 # solve the version of request compatible with docker and docker-compose
-requests==2.20.0
+requests<3,>=2.20.0


### PR DESCRIPTION
As for today, requests is pinned to version 2.20.0 which is not a recent version. And this easily generate conflicts with packages requiring newer versions of requests (I had to install requests 2.21 for the latest generateDS for instance).

From the requirements.txt history the 2.20.0 version was pinned 2 years ago to deal with docker-compose compatibility.
But today it seems we can accept newer versions of requests which help avoiding conflicts.

So for instance as you can see when you install the latest docker_compose-1.27.3, requests is relaxed to requests<3,>=2.20.0.
Here I attached the docker-compose log to show it:
```
rvalyi@rvalyi-laptop:~/DEV/generateds-2020$ sudo python3 -m pip install docker-compose --upgrade
Collecting docker-compose
  Downloading docker_compose-1.27.3-py2.py3-none-any.whl (110 kB)
     |????????????????????????????????| 110 kB 767 kB/s 
Requirement already satisfied, skipping upgrade: docopt<1,>=0.6.1 in /usr/lib/python3/dist-packages (from docker-compose) (0.6.2)
Requirement already satisfied, skipping upgrade: jsonschema<4,>=2.5.1 in /usr/lib/python3/dist-packages (from docker-compose) (3.2.0)
Requirement already satisfied, skipping upgrade: texttable<2,>=0.9.0 in /usr/lib/python3/dist-packages (from docker-compose) (1.6.2)
Collecting python-dotenv<1,>=0.13.0
  Downloading python_dotenv-0.14.0-py2.py3-none-any.whl (17 kB)
Requirement already satisfied, skipping upgrade: requests<3,>=2.20.0 in /usr/local/lib/python3.8/dist-packages (from docker-compose) (2.20.0)
Collecting docker[ssh]<5,>=4.3.1
  Downloading docker-4.3.1-py2.py3-none-any.whl (145 kB)
     |????????????????????????????????| 145 kB 1.8 MB/s 
Collecting distro<2,>=1.5.0
  Downloading distro-1.5.0-py2.py3-none-any.whl (18 kB)
Requirement already satisfied, skipping upgrade: dockerpty<1,>=0.4.1 in /usr/lib/python3/dist-packages (from docker-compose) (0.4.1)
Requirement already satisfied, skipping upgrade: PyYAML<6,>=3.10 in /usr/lib/python3/dist-packages (from docker-compose) (5.3.1)
Requirement already satisfied, skipping upgrade: websocket-client<1,>=0.32.0 in /usr/lib/python3/dist-packages (from docker-compose) (0.53.0)
Requirement already satisfied, skipping upgrade: cached-property<2,>=1.2.0 in /usr/lib/python3/dist-packages (from docker-compose) (1.5.1)
Requirement already satisfied, skipping upgrade: chardet<3.1.0,>=3.0.2 in /usr/lib/python3/dist-packages (from requests<3,>=2.20.0->docker-compose) (3.0.4)
Requirement already satisfied, skipping upgrade: urllib3<1.25,>=1.21.1 in /usr/local/lib/python3.8/dist-packages (from requests<3,>=2.20.0->docker-compose) (1.24.3)
Requirement already satisfied, skipping upgrade: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests<3,>=2.20.0->docker-compose) (2019.11.28)
Requirement already satisfied, skipping upgrade: idna<2.8,>=2.5 in /usr/local/lib/python3.8/dist-packages (from requests<3,>=2.20.0->docker-compose) (2.7)
Requirement already satisfied, skipping upgrade: six>=1.4.0 in /usr/lib/python3/dist-packages (from docker[ssh]<5,>=4.3.1->docker-compose) (1.14.0)
Requirement already satisfied, skipping upgrade: paramiko>=2.4.2; extra == "ssh" in /usr/lib/python3/dist-packages (from docker[ssh]<5,>=4.3.1->docker-compose) (2.6.0)
Installing collected packages: python-dotenv, docker, distro, docker-compose
  Attempting uninstall: docker
    Found existing installation: docker 4.1.0
    Not uninstalling docker at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'docker'. No files were found to uninstall.
  Attempting uninstall: distro
    Found existing installation: distro 1.4.0
    Not uninstalling distro at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'distro'. No files were found to uninstall.
  Attempting uninstall: docker-compose
    Found existing installation: docker-compose 1.25.0
    Not uninstalling docker-compose at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'docker-compose'. No files were found to uninstall.
Successfully installed distro-1.5.0 docker-4.3.1 docker-compose-1.27.3 python-dotenv-0.14.0
```

As for docker-compose master, requests==2.24.0 is required.