### PR TITLE
FIX import-metadata for python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ copier @ git+https://github.com/hparfr/copier@vcs_branch22-04#egg=copier
 # Only for solving installation issue with pip that fail to
 # solve the version of request compatible with docker and docker-compose
 requests<3,>=2.20.0
+importlib-metadata; python_version >= '3.10'


### PR DESCRIPTION
Make docky compatible with python 3.10

Since python 3.10

https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata

we need to install this dependency importlib.metadata

Many other app are impacted 
https://www.google.com/search?q=importlib.metadata.PackageNotFoundError%3A+No+package+metadata+was+found+for