### PR TITLE
[UPD]  Update Docky for Docker Compose v2

### DIFF
--- a/docky/__init__.py
+++ b/docky/__init__.py
@@ -3,4 +3,5 @@
 from . import cmd
 from . import common
 from .main import Docky
-from . import dcpatched
+# TODO: Check the command 'docky open'
+# from . import dcpatched

--- a/docky/cmd/base.py
+++ b/docky/cmd/base.py
@@ -13,7 +13,7 @@ from ..common.project import Project
 
 class Docky(cli.Application):
     PROGNAME = "docky"
-    VERSION = "8.0.0"
+    VERSION = "9.0.0"
     SUBCOMMAND_HELPMSG = None
 
     def _run(self, cmd, retcode=FG):
@@ -44,7 +44,7 @@ class DockySub(cli.Application):
 
     def _init_project(self):
         self.project = Project()
-        self.compose = local["docker-compose"]
+        self.compose = local["docker"]["compose"]
 
     def main(self, *args, **kwargs):
         if self._project_specific:

--- a/docky/cmd/base.py
+++ b/docky/cmd/base.py
@@ -18,13 +18,13 @@ class Docky(cli.Application):
 
     def _run(self, cmd, retcode=FG):
         """Run a command in a new process and log it"""
-        logger.debug(str(cmd).replace("/usr/local/bin/", ""))
+        logger.debug(str("$ " + str(cmd).rsplit("/")[-1]))
         return cmd & retcode
 
     def _exec(self, cmd, args=[]):
         """Run a command in the same process and log it
         this will replace the current process by the cmd"""
-        logger.debug(cmd + " ".join(args))
+        logger.debug(str("$ " + str(cmd).rsplit("/")[-1]  + " " + " ".join(args)))
         os.execvpe(cmd, [cmd] + args, local.env)
 
     @cli.switch("--verbose", help="Verbose mode", group="Meta-switches")

--- a/docky/cmd/kill.py
+++ b/docky/cmd/kill.py
@@ -3,7 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from .base import Docky, DockySub
-from compose.parallel import parallel_kill
 
 
 @Docky.subcommand("kill")
@@ -13,5 +12,4 @@ class DockyKill(DockySub):
     def _main(self, *args):
         # docker compose do not kill the container odoo as is was run
         # manually, so we implement our own kill
-        containers = self.project.get_containers()
-        parallel_kill(containers, {"signal": "SIGKILL"})
+        self._run(self.compose["kill", "-s", "SIGKILL"])

--- a/docky/cmd/run_open.py
+++ b/docky/cmd/run_open.py
@@ -2,9 +2,12 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import sys
 from plumbum import cli
 from .base import Docky, DockySub
-from ..common.api import raise_error
+from ..common.api import raise_error, logger
+
+from python_on_whales import docker
 
 
 class DockyExec(DockySub):
@@ -79,3 +82,27 @@ class DockyOpen(DockyExec):
     def _main(self, *optionnal_command_line):
         super()._main(*optionnal_command_line)
         self._exec("dcpatched", ["exec", "-e", "NOGOSU=True", self.service] + self.cmd)
+
+@Docky.subcommand("system")
+class DockySystem(DockyExec):
+    """
+    Check your System Infos:
+    OS Type, Kernel, OS, Docker, Docker Compose, and Docky versions.
+    """
+    def _main(self):
+        # Info
+        infos = docker.system.info()
+        # OS Type
+        logger.info("OS Type " + infos.os_type)
+        # Kernel Version
+        logger.info("Kernel Version " + infos.kernel_version)
+        # Operation System
+        logger.info("OS " + infos.operating_system)
+        # Python Version
+        logger.info("Python Version " + sys.version)
+        # Docker Version
+        logger.info("Docker Version " + infos.server_version)
+        # Docker Compose Version
+        logger.info(docker.compose.version())
+        # Docky Version
+        logger.info("Docky Version " + Docky.VERSION)

--- a/docky/cmd/run_open.py
+++ b/docky/cmd/run_open.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import sys
+import subprocess
 from plumbum import cli
 from .base import Docky, DockySub
 from ..common.api import raise_error, logger
@@ -19,7 +20,10 @@ class DockyExec(DockySub):
     service = cli.SwitchAttr(["service"])
 
     def _use_specific_user(self, service):
-        return not self.root and self.project.get_user(service)
+        user = self.project.get_user(service)
+        if self.root:
+            user = "root"
+        return user
 
     def _get_cmd_line(self, optionnal_command_line):
         user = self._use_specific_user(self.service)
@@ -81,7 +85,24 @@ class DockyOpen(DockyExec):
 
     def _main(self, *optionnal_command_line):
         super()._main(*optionnal_command_line)
-        self._exec("dcpatched", ["exec", "-e", "NOGOSU=True", self.service] + self.cmd)
+        # self._exec("dcpatched", ["exec", "-e", "NOGOSU=True", self.service] + self.cmd)
+
+        # Get Project Name
+        # Example:     docky-odoo-brasil-14      odoo
+        project_name = self.project.name + "-" + self.project.service
+
+        # Get User
+        user = self._use_specific_user(self.service)
+
+        # Get Container ID
+        command = "docker ps -aqf name=" + project_name
+        # Example of return value
+        # b'b5db9db21381\n'
+        # Option text=true return as string instead of bytes and strip remove break line
+        # TODO: Is there a better way to do it, for example with Plumbum?
+        container_id = subprocess.check_output(command, shell=True,text=True).strip()
+
+        self._exec("docker", ["exec", "-u", user, "-it", container_id, "/bin/bash"])
 
 @Docky.subcommand("system")
 class DockySystem(DockyExec):

--- a/docky/cmd/run_open.py
+++ b/docky/cmd/run_open.py
@@ -57,9 +57,17 @@ class DockyRun(DockyExec):
         self._run(self.compose["rm", "-f"])
         self.project.display_service_tooltip()
         self.project.create_volume()
-        self._exec("docker-compose", [
-            "run", "--rm", "--service-ports", "--use-aliases", "-e", "NOGOSU=True",
-            self.service] + self.cmd)
+        # Default command
+        docky_cmd = ["run", "--rm", "--service-ports", "--use-aliases", "-e", "NOGOSU=True", self.service] + self.cmd
+
+        self._exec("docker", ["compose"] + docky_cmd)
+
+        # TODO: Should we use python-on-whales commands?
+        #  Its possible make
+        # docker.compose.run(self.project.name, and other parameters)
+        # But until now was not possible make the same command as above,
+        # if its possible we should consider the option to use it.
+        # https://gabrieldemarmiesse.github.io/python-on-whales/sub-commands/compose/
 
 
 @Docky.subcommand("open")

--- a/docky/common/project.py
+++ b/docky/common/project.py
@@ -14,8 +14,8 @@ class Project(object):
         try:
             self.project = docker.compose.config(return_json=True)
         except:
-            print("No docker-compose found, create one with :")
-            print("$ docky init")
+            logger.error("No docker-compose file found, create one with :")
+            logger.error("$ docky init")
             exit(-1)
 
         self.name = self.project.get("name")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-docker-compose>=1.23.1
+python-on-whales
 plumbum
 rainbow_logging_handler
 python-slugify
-# Only for solving installation issue with pip that fail to
-# solve the version of request compatible with docker and docker-compose
-requests<3,>=2.20.0
-importlib-metadata; python_version >= '3.10'
-PyYAML >= 5.1, < 5.4
+requests
+importlib-metadata
+PyYAML >= 6.0.1


### PR DESCRIPTION
Update Docky for Docker Compose v2
==============================

Docker Compose V1 is deprecated 

https://github.com/docker/compose

Warning

> The final Compose V1 release, version 1.29.2, was May 10, 2021. These packages haven't received any security updates since then. Use at your own risk.

https://docs.docker.com/compose/migrate/

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

> Compose V2, which was first released in 2020, is included with all currently supported versions of Docker Desktop. It offers an improved CLI experience, improved build performance with BuildKit, and continued new-feature development.


Some recently updates in the Python and PyYAML seems cause errors in Docky

```
$ docky build
Traceback (most recent call last):
  File "/home/test/.local/bin/docky", line 8, in <module>
    sys.exit(main())
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/docky/main.py", line 7, in main
    Docky.run()
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/plumbum/cli/application.py", line 638, in run
    inst, retcode = subapp.run(argv, exit=False)
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/plumbum/cli/application.py", line 633, in run
    retcode = inst.main(*tailargs)
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/docky/cmd/base.py", line 53, in main
    self._init_project()
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/docky/cmd/base.py", line 48, in _init_project
    self.project = Project()
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/docky/common/project.py", line 19, in __init__
    self.project = command.project_from_options('.', {})
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/compose/cli/command.py", line 60, in project_from_options
    return get_project(
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/compose/cli/command.py", line 152, in get_project
    client = get_client(
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/compose/cli/docker_client.py", line 41, in get_client
    client = docker_client(
  File "/home/test/.local/share/pipx/venvs/docky/lib64/python3.9/site-packages/compose/cli/docker_client.py", line 124, in docker_client
    kwargs = kwargs_from_env(environment=environment, ssl_version=tls_version)
TypeError: kwargs_from_env() got an unexpected keyword argument 'ssl_version'
```

If you try to reinstall Docky

```
$ pipx install docky --force

pip seemed to fail to build package:
    PyYAML<6,>=3.10

Some possibly relevant errors from pip install:
    error: subprocess-exited-with-error
    AttributeError: cython_sources


Collecting PyYAML<6,>=3.10 (from docker-compose>=1.23.1->docky)
  Using cached PyYAML-5.4.1.tar.gz (175 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'



          self.filelist.extend(build_ext.get_source_files())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<string>", line 201, in get_source_files
        File "/tmp/pip-build-env-5rd4lxrc/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
```

PyYAML
- Error installing Pyyaml==5.4, Cython_sources 
Maybe related with the Issue 724 https://github.com/yaml/pyyaml/issues



To fix it's need to update from 'docker-compose' V1 in Python to 'docker compose' V2 in GO, by the change of the language is not more possible import docker compose direct by python, some projects try to reimplement:

- Docker-Py https://github.com/docker/docker-py

- Python on whales https://github.com/gabrieldemarmiesse/python-on-whales

- Docker Composer V2 https://github.com/jensenkairos/docker-composer-v2


I'm choosed Python-on-whales 

> from python_on_whales import docker
> project_config = docker.compose.config()
> print(project_config.services["my_first_service"].image)
> "redis"


> * 1 to 1 mapping between the CLI interface and the Python API. No need to look in the docs what is the name of the function/argument you need.
> * Support for the latest Docker features: Docker buildx/buildkit, docker run --gpu=all ...

> While Docker-py is a complete re-implementation of the Docker client binary (written in Go), Python on whales sits on top of the Docker client binary, which makes implementing new features much easier and safer. For example, it's unlikely that docker-py supports Buildx/buildkit anytime soon because rewriting a large Go codebase in Python is hard work.


Some considerations


> Should I use Docker-py or Python on Whales?

> Well, it's written in each project's description!

>    Docker-py: A Python library for the Docker Engine API
>   Python on whales: An awesome Python wrapper for an awesome Docker CLI

> If you need to talk to the Docker engine directly, you need to do low level operations, use docker-py. Some good example >  would be writing the code to control docker from an IDE, or if the speed of Docker calls is very important. If you don't want  to depend on the Docker CLI binary (~50MB), use docker-py.

> If you wanted to call the docker command line from Python, do high level operations, use Python on Whales. For example  if you want to write your CI logic in Python rather than in bash (a very good choice 😉). Some commands are only available in Python on whales too: docker.buildx.build(...), docker.stack.deploy(...)...

Here python-on-whales are just use for get Config files from project, it's possible use some of the commands like docker.compose.run() and others https://gabrieldemarmiesse.github.io/python-on-whales/sub-commands/compose/ but I keep it as before by Plumbum run in bash '$ docker compose run ...'.

Included a new command 'docky system' to get some System Infos OS Type, Kernel, OS, Docker, Docker Compose, and Docky versions; just to make easy debug errors related to some OS or old or new libraries versions, it's just a resume of '$ docker info'.
Tests was made with: 
* Ubuntu 24.04 ( package docker-compose-v2 ) 

![image](https://github.com/akretion/docky/assets/6341149/826a1deb-c1c6-407b-b65e-ee5035871b49)

* Slackware 15.0 current

![image](https://github.com/akretion/docky/assets/6341149/b744737c-e97d-40a1-94ff-bba2095a7f11)


In the case you are testing with another OS check the versions of the main libraries, tests with other OSs are welcome, should be better extract this commit? For testing the change for v2 seems usefull for debug but if necessary I can extract.   

The Docky commnands working are **build run logs ps up down kill restart** in both OS , command **docky open** return error, the problem seems related to file dcpatched.py ( I let this file commented in the __init to avoid error with import, need to check if still is necessary, any help are welcome ) and **docky pull** need to be test.

Integrated the PR https://github.com/akretion/docky/pull/151 , with this LOG show the command(s) execute, I'm add "$ " before to show as a command
docker compose ps
$ docker compose ps / Should be better keep without $ ?

![image](https://github.com/akretion/docky/assets/6341149/0f78a7e2-f18c-4935-82f2-87b483652a31)



It's been usefull see what the command will be execute for check errors but there are a debate in the PR about this change, if necessary I can extract this commit.


I'm also tried integrated the PR https://github.com/akretion/docky/pull/152 for use pyproject.toml, but return error when try to install
$ pipx install path_of_file/ --force
```
File "/tmp/pip-build-env-xkrei3u2/overlay/lib/python3.11/site-packages/hatchling/metadata/core.py", line 248, in _get_version
          version = self.hatch.version.cached
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-xkrei3u2/overlay/lib/python3.11/site-packages/hatchling/metadata/core.py", line 1466, in cached
          raise type(e)(message) from None
      ValueError: Error getting the version from source `regex`: unable to parse the version from the file: docky/__init__.py
      [end of output]
```

Other simple changes was made to removed deprecated encoding, change in License Header from '2018' to '2018-TODAY', call method super() don't need parameters, change simple quotes ' for double quotes " in python files and in the message about missing compose_file.py change print for logger.error.

![image](https://github.com/akretion/docky/assets/6341149/7b4353cf-7d12-4e5b-9367-a5ccfa131d64)


The tests was made with a generic project in v14 with Brazilian Localization, futher tests with complex compose.yml parameters are welcome and necessary for a better review. 

There are a error with Traefik when you run 'docky build', the log message don't show the complete error as 'docker compose build'

```
Error response from daemon: network traefik not found
```

Docker Compose show the complete erro with the fix 

```
ERROR: Network traefik declared as external, but could not be found. Please create the network manually using `docker network create traefik` and try again.
```

Should be better if Docky show the same message or included the suggestion to solve.

If necessary, as said before, some committs can be extract for others PRs for a better review.

cc @rvalyi @renatonlima 