### PR TITLE
`The built wheel `docky-9.0.4-py34+-none-any.whl` is not compatible with the current Python 3.11 on manylinux x86_64`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
 [aliases]
 test=pytest
-
-[bdist_wheel]
-# universal = 1
-python-tag = py34+


### PR DESCRIPTION
Is this python tag really useful? Because it currently breaks my uv project (in python 10, 11, 12, 13 and 14):

```
Creating virtual environment at: akretion/.venv
      Built docky @ git+https://github.com/akretion/docky@4629ad2bdf18aa7aa06b308c6255a41ce4af79ae
  × Failed to download and build `docky @ git+https://github.com/akretion/docky@4629ad2bdf18aa7aa06b308c6255a41ce4af79ae`
  ╰─▶ The built wheel `docky-9.0.4-py34+-none-any.whl` is not compatible with the current Python 3.11 on manylinux x86_64
  help: `docky` was included because `akretion` (v0.1.0) depends on `docky`
```